### PR TITLE
Add JSON-RPC 1.0 support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,8 @@ var Client = function(server, options) {
   var defaults = {
     reviver: null,
     replacer: null,
-    generator: utils.generateId
+    generator: utils.generateId,
+    version: 2
   };
 
   this.options = utils.merge(defaults, options || {});
@@ -52,7 +53,8 @@ Client.fork = require('./client/fork');
  *  @param {Array|Object} params Parameters for the method
  *  @param {String|Number} [id] Optional id. If undefined an id will be generated. If null it creates a notification request
  *  @param {Function} [callback] Request callback. If specified, executes the request rather than only returning it.
- *  @return {Object} JSON-RPC 2.0 compatible request
+ *  @throws {TypeError} Invalid parameters
+ *  @return {Object} JSON-RPC 1.0 or 2.0 compatible request
  *  @api public
  */
 Client.prototype.request = function(method, params, id, callback) {
@@ -60,6 +62,10 @@ Client.prototype.request = function(method, params, id, callback) {
 
   // is this a batch request?
   var isBatch = Array.isArray(method) && typeof(params) === 'function';
+
+  // JSON-RPC 1.0 doesn't support batching
+  if (this.options.version === 1 && isBatch)
+    throw new TypeError('JSON-RPC 1.0 does not support batching')
 
   // is this a raw request?
   var isRaw = !isBatch && method && typeof(method) === 'object' && typeof(params) === 'function';
@@ -77,7 +83,8 @@ Client.prototype.request = function(method, params, id, callback) {
 
     try {
       var request = utils.request(method, params, id, {
-        generator: this.options.generator
+        generator: this.options.generator,
+        version: this.options.version
       });
     } catch(err) {
       if(hasCallback) return callback(err);
@@ -124,7 +131,7 @@ Client.prototype.request = function(method, params, id, callback) {
 
 /**
  *  Executes a request on server bound directly
- *  @param {Object} request A JSON-RPC 2.0 request
+ *  @param {Object} request A JSON-RPC 1.0 or 2.0 request
  *  @param {Function} [callback] Request callback that will receive the server response as the second argument
  *  @return {void}
  *  @api private

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,8 @@ var Server = function(methods, options) {
   var defaults = {
     reviver: null,
     replacer: null,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    version: 2
   };
 
   this.options = utils.merge(defaults, options || {});
@@ -188,15 +189,19 @@ Server.prototype.call = function(request, originalCallback) {
       request = JSON.parse(request, this.options.reviver);
     } catch(exception) {
       var error = this.error(Server.errors.PARSE_ERROR, null, exception);
-      return callback(utils.response(error));
+      return callback(utils.response(error, this.options.version));
     }
   }
 
   // is this a batch request?
   if(Array.isArray(request)) {
+    // batch requests not allowed for version 1
+    if(this.options.version === 1)
+      return callback(utils.response(this.error(Server.errors.INTERNAL_ERROR), this.options.version));
+
     // special case if empty batch request
     if(!request.length) {
-      return callback(utils.response(this.error(Server.errors.INVALID_REQUEST)));
+      return callback(utils.response(this.error(Server.errors.INVALID_REQUEST), this.options.version));
     }
     return this._batch(request, callback);
   }
@@ -204,14 +209,14 @@ Server.prototype.call = function(request, originalCallback) {
   this.emit('request', request);
 
   // is the request valid?
-  if(!isValidRequest(request)) {
-    return callback(utils.response(this.error(Server.errors.INVALID_REQUEST)));
+  if(!isValidRequest(request, this.options.version)) {
+    return callback(utils.response(this.error(Server.errors.INVALID_REQUEST), this.options.version));
   }
 
   // from now on we are "notification"-aware and can deliberately ignore errors for such requests
   var respond = function(error, result) {
     if(isNotification(request)) return callback();
-    var response = utils.response(error, result, request.id);
+    var response = utils.response(error, result, request.id, self.options.version);
     if(response.error) callback(response);
     else callback(null, response);
   };
@@ -293,7 +298,7 @@ Server.prototype._batch = function(requests, callback) {
   var wrapper = function(request, index) {
     responses[index] = null;
     return function() {
-      if(!isValidRequest(request)) {
+      if(!isValidRequest(request, self.options.version)) {
         responses[index] = utils.response(self.error(Server.errors.INVALID_REQUEST));
         maybeRespond();
       } else {
@@ -320,17 +325,18 @@ Server.prototype._batch = function(requests, callback) {
  * Is the passed argument a valid JSON-RPC request?
  * @ignore
  */
-function isValidRequest(request) {
+function isValidRequest(request, version) {
   return Boolean(
     request
     && typeof(request) === 'object'
-    && request.jsonrpc === '2.0'
+    && (version === 2 ? request.jsonrpc === '2.0' : typeof(request.jsonrpc) === 'undefined')
     && typeof(request.method) === 'string'
     && (
       typeof(request.params) === 'undefined'
       || Array.isArray(request.params)
       || (request.params && typeof(request.params) === 'object')
     )
+    && (version === 1 ? Array.isArray(request.params) : true)
     && (
       typeof(request.id) === 'undefined'
       || typeof(request.id) === 'string'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,13 +4,13 @@ var util = require('util');
 var Utils = module.exports;
 
 /**
- *  Generates a JSON-RPC 2.0 request
+ *  Generates a JSON-RPC 1.0 or 2.0 request
  *  @param {String} method Name of method to call
  *  @param {Array|Object} params Array of parameters passed to the method as specified, or an object of parameter names and corresponding value
  *  @param {String|Number|null} [id] Request ID can be a string, number, null for explicit notification or left out for automatic generation
  *  @param {Object} [options] Optional name => value pairs of settings
  *  @throws {TypeError} If any of the parameters are invalid
- *  @return {Object} A JSON-RPC 2.0 request
+ *  @return {Object} A JSON-RPC 1.0 or 2.0 request
  *  @api public
  */
 Utils.request = function(method, params, id, options) {
@@ -25,15 +25,17 @@ Utils.request = function(method, params, id, options) {
   options = options || {};
 
   var request = {
-    jsonrpc: "2.0",
     params: params,
     method: method
   };
 
+  // assume that we are doing a 2.0 request unless specified differently
+  if (typeof(options.version) === 'undefined' || options.version !== 1) request.jsonrpc = "2.0";
+
   // if id was left out, generate one (null means explicit notification)
   if(typeof(id) === 'undefined') {
     var generator = typeof(options.generator) === 'function' ? options.generator : Utils.generateId;
-    request.id =  generator(request);
+    request.id = generator(request, options);
   } else {
     request.id = id;
   }
@@ -42,16 +44,26 @@ Utils.request = function(method, params, id, options) {
 };
 
 /**
- *  Generates a JSON-RPC 2.0 response
+ *  Generates a JSON-RPC 1.0 or 2.0 response
  *  @param {Object} error Error member
  *  @param {Object} result Result member
  *  @param {String|Number|null} id Id of request
- *  @return {Object} A JSON-RPC 2.0 response
+ *  @param {Number} version JSON-RPC version to use
+ *  @return {Object} A JSON-RPC 1.0 or 2.0 response
  *  @api public
  */
-Utils.response = function(error, result, id) {
+Utils.response = function(error, result, id, version) {
+  // allow result and id to be optional arguments
+  version = typeof(result) === 'number' ? result : version;
+
   id = typeof(id) === 'undefined' || id === null ? null : id;
-  var response = { jsonrpc: "2.0", id: id };
+  error = typeof(error) === 'undefined' || error === null ? null : error;
+  version = typeof(version) === 'undefined' || version === null ? 2 : version;
+  var response = (version === 2) ? { jsonrpc: "2.0", id: id } : { id: id };
+
+  // errors are always included in version 1
+  if(version === 1) response.error = error;
+
   // one or the other with precedence for errors
   if(error) response.error = error;
   else response.result = result;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -39,6 +39,8 @@ describe('jayson server instance', function() {
     server.removeMethod.should.be.a('function');
     should.exist(server.errorMessages);
     server.errorMessages.should.be.a('object');
+    should.exist(server.options);
+    server.options.should.be.a('object');
   });
 
   it('should allow a method to be added and removed', function() {
@@ -370,6 +372,23 @@ describe('jayson server instance', function() {
   });
 
   describe('batch requests', function() {
+
+    it('should error when version is 1', function(done) {
+      server.options.version = 1;
+      var requests = [
+        utils.request('add', [1, 1]),
+        utils.request('add', [2, 2])
+      ];
+      server.call(requests, function(err, response) {
+        should.not.exist(response);
+        should.exist(err);
+        should.exist(err.error);
+        should.exist(err.error.code);
+        err.error.code.should.equal(-32603); // "Internal Error"
+        done();
+      });
+      server.options.version = 2;
+    });
 
     it('should handle an empty batch', function(done) {
       server.call([], function(err, response) {


### PR DESCRIPTION
Adds JSON-RPC 1.0 support, defaults to using 2.0. Version is set in the options.

May be a bit rough around the edges, but otherwise should conform to the spec and passes the added tests.
