### PR TITLE
Handle requests without "params"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -183,6 +183,7 @@ Utils.httpRequestWrapper = function(server) {
     Utils.parseBody(req, options, function(err, request) {
       // parsing failed, 500 server error
       if(err) return respondError(err, 500);
+      request.params = request.params || {};
 
       server.call(request, function(error, success) {
         var response = error || success;


### PR DESCRIPTION
As the 2.0 specification says, this member MAY be omitted.
(see http://www.jsonrpc.org/specification#request_object)
