### PR TITLE
Fix tcp client data sending

### DIFF
--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -42,7 +42,6 @@ TcpClient.prototype._request = function(request, callback) {
     conn.setEncoding(options.encoding);
     utils.parseBody(conn, options, function(err, response) {
       handled = true;
-      conn.end();
       if (err)
         return callback(err);
       callback(null, response);
@@ -58,6 +57,6 @@ TcpClient.prototype._request = function(request, callback) {
         callback();
     });
 
-    conn.write(body);
+    conn.end(body);
   });
 };


### PR DESCRIPTION
Actually #net.end() half-close connection and not break connection, its
needed to server implementation with 'FIN' packet waiting - anyway we
are ending connection in this method.
