### PR TITLE
Changes to server.middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,10 @@ var server = jayson.server({
 // parse request body before the jayson middleware
 app.use(connect.bodyParser());
 app.use(server.middleware());
-
+    /*
+    if you need Connect or Express to continue with next middleware:
+      app.use(server.middleware({shouldContinue: true}));
+    */
 app.listen(3000);
 ````
 

--- a/lib/server/middleware.js
+++ b/lib/server/middleware.js
@@ -35,9 +35,13 @@ var Middleware = function(server, options) {
           };
           res.writeHead(200, headers);
           res.write(body);
-          res.end();
         } else {
           res.writeHead(204);
+        }
+
+        if(options.shouldContinue) {
+          next();
+        } else {
           res.end();
         }
 

--- a/lib/server/middleware.js
+++ b/lib/server/middleware.js
@@ -10,7 +10,7 @@ var utils = require('../utils');
  */
 var Middleware = function(server, options) {
   return function(req, res, next) {
-    var options = utils.merge(server.options, options || {});
+    var optionsMerged = utils.merge(server.options, options || {});
 
     //  405 method not allowed if not POST
     if(!utils.isMethod(req, 'POST')) return error(405, { 'allow': 'POST' });
@@ -24,13 +24,13 @@ var Middleware = function(server, options) {
     server.call(req.body, function(error, success) {
       var response = error || success;
 
-      utils.JSON.stringify(response, options, function(err, body) {
+      utils.JSON.stringify(response, optionsMerged, function(err, body) {
         if(err) return next(err);
 
         // empty response?
         if(body) {
           var headers = {
-            "Content-Length": Buffer.byteLength(body, options.encoding),
+            "Content-Length": Buffer.byteLength(body, optionsMerged.encoding),
             "Content-Type": "application/json"
           };
           res.writeHead(200, headers);
@@ -39,7 +39,7 @@ var Middleware = function(server, options) {
           res.writeHead(204);
         }
 
-        if(options.shouldContinue) {
+        if(optionsMerged.shouldContinue) {
           next();
         } else {
           res.end();


### PR DESCRIPTION
Hey!

I have encountered an issue while trying to use **jayson** as a *middleware* for Connect. Let me introduce one use case:

Our app is used as a JSON-RPC server, where users needs authorization. So, in order to achieve that, we would like to have one "route" for serving authorization (creating sessions etc.) and other "route" for serving json-rpc responses. In order to achieve that:

* We have to get name of the json-rpc method (e.g. "signIn") and invoke authorization callback
* Use Connect middleware for creating sessions
* Send response to user.

So, it would be great if jayson middleware used *next()* instead of *res.end()*. That is the content of the "New option to invoke next() in middleware" commit. I have introduced a new option "shouldContinue" for this purpose.

During testing this, I have encountered a bug. Variable *options* is introduced with **var** keyword, so original *options* is replaced with undefined. I have renamed it.

Regards,
Jan