### PR TITLE
Accept most types of errors when using v1

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -261,7 +261,7 @@ Server.prototype.call = function(request, originalCallback) {
 
     // the callback that server methods receive
     args.push(function(error, result) {
-      if(isValidError(error)) return respond(error);
+      if(self._isValidError(error)) return respond(error);
 
       // got an invalid error
       if(error) return respond(self.error(Server.errors.INTERNAL_ERROR));
@@ -340,14 +340,17 @@ Server.prototype._batch = function(requests, callback) {
  * Is the passed argument a valid JSON-RPC error?
  * @ignore
  */
-function isValidError(error) {
+Server.prototype._isValidError = function(error) {
+  if(this.options.version === 1) {
+    return typeof(error) !== 'undefined' && error !== null;
+  }
   return Boolean(
     error
     && typeof(error.code) === 'number'
     && parseInt(error.code) == error.code
     && typeof(error.message) === 'string'
   );
-}
+};
 
 /**
  * Parse "request" if it is a string, else just invoke callback

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -86,7 +86,23 @@ describe('jayson server instance', function() {
       var error = server.error(code, null, data);
       error.should.have.property('data', data);
     });
-  
+
+    describe('with a version 1.0 server', function() {
+
+      beforeEach(function() {
+        server.options.version = 1;
+      });
+
+      it('should consider a string a valid error', function() {
+        server.method('errorMethod', function(callback) {
+          callback('an error');
+        });
+        var request = utils.request('errorMethod', []);
+        server.call(request, function(err, response) {
+          err.error.should.eql('an error');
+        });
+      });
+    });
   });
 
   describe('router', function() {


### PR DESCRIPTION
JSON-RPC v1 accepts any type as error. Previously errors were checked
only against the v2 specification, which requires error to be an object.
Nothing is mentioned of this in the JSON-RPC v1 specification therefore
we now accept any error if the version is 1.

This version will however still not handle errors that are falsy (false,
"", 0 etc) properly.