### PR TITLE
Fix issue where request id is not relayed

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -231,7 +231,7 @@ Server.prototype.call = function(request, originalCallback) {
 
     // are we attempting to invoke a relayed method?
     if(method instanceof jayson.Client) {
-      return method.request(request.method, request.params, function(err, response) {
+      return method.request(request.method, request.params, request.id, function(err, response) {
         if(utils.Request.isNotification(request)) return callback();
         callback(err, response);
       });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -117,6 +117,30 @@ describe('jayson server instance', function() {
   
   });
 
+  describe('jayson.Client router', function() {
+    var client = null;
+
+    beforeEach(function() {
+      client = jayson.client(server, support.server.options);
+      server.options.router = function(method) {
+        return client;
+      };
+    });
+
+    it('should forward id', function(done) {
+      var request = utils.request('method', [], 'test_event_id');
+
+      client._request = function(request, cb) {
+        request.id.should.eql('test_event_id');
+        cb(null);
+      };
+
+      server.call(request, function() {
+        done();
+      });
+    });
+  });
+
   describe('event handlers', function() {
 
     (function() {


### PR DESCRIPTION
When the router returns another client (in order to relay requests) the
id of the original client was being ignored and a new one generated.

Now the request id of the original client is being forwarded all the way
to the routed-to client.