### PR TITLE
Feature/handle server notifications

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -25,6 +25,8 @@ var Client = function(server, options) {
     version: 2
   };
 
+  this._notifications = {};
+
   this.options = utils.merge(defaults, options || {});
 
   if(server) this.server = server;
@@ -137,6 +139,39 @@ Client.prototype._request = function(request, callback) {
 
   });
 
+};
+
+Client.prototype.notify = function(request) {
+  function getArgs(params) {
+    if(request.params && !Array.isArray(request.params)) {
+      return parameters.map(function(name) {
+        return request.params[name];
+      });
+    }
+
+    if(Array.isArray(request.params)) {
+      return request.params;
+    }
+    return [];
+  }
+
+  if (this.options.version !== 1) {
+    throw new TypeError('Only JSON-RPC 1.0 supports reciveing notifications from servers');
+  }
+
+  if (request.method in this._notifications) {
+    this.emit('notification', request);
+    var method = this._notifications[request.method];
+    var args = getArgs(request.params);
+
+    method.apply(null, args);
+  }
+};
+
+Client.prototype.notification = function(name, definition) {
+  if(typeof(definition) !== 'function') throw new TypeError(definition + ' must be a function');
+  if(!name || typeof(name) !== 'string') throw new TypeError(name + ' must be a non-zero length string');
+  this._notifications[name] = definition;
 };
 
 /**

--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -23,6 +23,8 @@ var TcpClient = function(options) {
     encoding: 'utf8'
   });
 
+  this._outstandingRequests = {};
+
   this.options = utils.merge(defaults, options || {});
 };
 require('util').inherits(TcpClient, Client);
@@ -30,6 +32,15 @@ require('util').inherits(TcpClient, Client);
 module.exports = TcpClient;
 
 TcpClient.prototype._request = function(request, callback) {
+  if (this.options.version === 1) {
+    this._keepConnectionRequest(request, callback);
+  }
+  else {
+    this._closeConnectionRequest(request, callback);
+  }
+};
+
+TcpClient.prototype._closeConnectionRequest = function(request, callback) {
   var self = this;
 
   // copies options so object can be modified in this context
@@ -76,4 +87,86 @@ TcpClient.prototype._request = function(request, callback) {
       if(!handled) callback(); 
     });
   });
+};
+
+TcpClient.prototype._keepConnectionRequest = function(request, callback) {
+  var self = this;
+
+  // copies options so object can be modified in this context
+  var options = utils.merge({}, this.options);
+
+  function setupConnection() {
+    self.conn = net.connect(options, function() {
+      self.connected = true;
+    });
+    self.conn.setEncoding(options.encoding);
+    utils.parseStream(self.conn, options, self._handleIncoming.bind(self));
+
+    self.conn.on('error', function(err) {
+      self.emit('tcp error', err);
+      self._finishOutstanding(err);
+    });
+
+    self.conn.on('end', function() {
+      self._finishOutstanding();
+    });
+  }
+
+  function write(data) {
+    if (!self.conn) {
+      setupConnection();
+    }
+
+    if (self.connected) {
+      self.conn.write(data);
+    }
+    else {
+      self.conn.on('connect', function() {
+        self.conn.write(data);
+      });
+    }
+  }
+
+  utils.JSON.stringify(request, options, function(err, body) {
+    if(err) return callback(err);
+
+    // wont get anything for notifications, just end here
+    if(utils.Request.isNotification(request)) {
+      callback();
+    } else {
+      self._outstandingRequests[request.id] = callback;
+      write(body);
+    }
+  });
+};
+
+TcpClient.prototype._handleIncoming = function(err, msg) {
+  if (err) {
+    // We couldn't parse the incoming request, according to JSON-RPC 1 we
+    // should then close the connection
+    return this.conn.end();
+  }
+  if (utils.Request.isNotification(msg)) {
+    return this.notify(msg);
+  }
+
+  if (msg.id in this._outstandingRequests) {
+    var callback = this._outstandingRequests[msg.id];
+    delete this._outstandingRequests[msg.id];
+    return callback(null, msg);
+  }
+
+  // If we fall through here it means we got a response without an outstanding
+  // request, which is an error, thus we close the connection as per the
+  // JSON-RPC 1 spec
+  this.conn.end();
+};
+
+TcpClient.prototype._finishOutstanding = function(err) {
+  for (var id in this._outstandingRequests) {
+    var callback = this._outstandingRequests[id];
+    callback(err);
+  }
+
+  this._outstandingRequests = {};
 };

--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -108,7 +108,7 @@ TcpClient.prototype._keepConnectionRequest = function(request, callback) {
     });
 
     self.conn.on('end', function() {
-      self._finishOutstanding();
+      self._finishOutstanding(new Error('No response'));
     });
   }
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2,6 +2,7 @@ var should = require('should');
 var jayson = require(__dirname + '/..');
 var support = require(__dirname + '/support');
 var common = support.common;
+var utils = jayson.utils;
 
 describe('jayson client object', function() {
 
@@ -177,6 +178,40 @@ describe('jayson client instance', function() {
       should.not.exist(error);
       response.should.equal(5 - 2);
       done();
+    });
+  });
+
+  describe('server sent notifications', function() {
+    describe('with JSON-RPC version 1', function() {
+      beforeEach(function() {
+        client.options.version = 1;
+      });
+
+      it('should support recieving notifications', function(done) {
+        var request = utils.request('notification_method', [], null, {
+          version: 1
+        });
+        client.notification('notification_method', function() {
+          true.should.be.ok;
+          done();
+        });
+        client.notify(request);
+      });
+    });
+
+    describe('with JSON-RPC version 2', function() {
+      beforeEach(function() {
+        client.options.version = 2;
+      });
+      it('should not accept notifications', function() {
+        var request = utils.request('notification_method', [], null, {
+          version: 2
+        });
+
+        (function() {
+          client.notify(request);
+        }).should.throw();
+      });
     });
   });
 


### PR DESCRIPTION
I'm using JSON-RPC version 1 for commnicating with an embedded device over USB-serial. One ability we need for that is to be able to send notifications from the server (the embedded device) to the client.

There is support for notifications from the server to the client in JSON-RPC 1, the two endpoints are more peers than actual client/server.

a58d7d5 contains most of what is interesting for the actual client support, I also tried to change the tcp client to take advantage of this new functionallity. In order to do so I had to keep connections open indefinitly (instead of closing them right away) and actually make sure the reponses we are getting actually corresponds to an outstanding request. 

I created this pull request mostly to start a discussion on how to approach the problem, I'm not convinced I like the way I did the tcp client implementation as it is breaks backwards compability. Perhaps adding an option for this behaviour is the right way forward?