### PR TITLE
Broken link in the TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Jayson is a [JSON-RPC 2.0][jsonrpc-spec] compliant server and client written in 
 - [Features](#features)
 - [Example](#example)
 - [Installation](#installation)
-- [Changelog](#changelog)
+- [Changelog](#changelog-notable-milestones)
 - [Requirements](#requirements)
 - [Class Documentation](#class-documentation)
 - [Running tests](#running-tests)


### PR DESCRIPTION
With https://github.com/tedeh/jayson/commit/3ceb804e5f31cbb627956d5fd5b1642e7b1a24d4, the link to the changelog in the TOC has been broken.