### PR TITLE
CLI enhancements

### DIFF
--- a/bin/jayson.js
+++ b/bin/jayson.js
@@ -9,6 +9,7 @@ var pkg = require('../package.json');
 var jayson = require('../');
 var program = require('commander');
 var eyes = require('eyes');
+var net = require('net')
 
 // initialize program and define arguments
 program.version(pkg.version)
@@ -16,7 +17,7 @@ program.version(pkg.version)
        .option('-p, --params [json]', 'Array or Object to use as parameters', JSON.parse)
        .option('-u, --url [url]', 'URL to server', url.parse)
        .option('-q, --quiet', 'Only output the response value and any errors', Boolean)
-       .option('-s, --socket [path]', 'Path to UNIX socket', parseSocket)
+       .option('-s, --socket [path] or [ip:port]', 'Path to UNIX socket, or TCP socket address', parseSocket)
        .option('-j, --json', 'Only output the response value as JSON (implies --quiet)', Boolean)
        .option('-c, --color', 'Color output', Boolean)
        .parse(process.argv);
@@ -41,7 +42,9 @@ if(!(program.method && program.params && (program.url || program.socket))) {
   return process.exit(-1);
 }
 
-var client = jayson.client.http(program.url || program.socket);
+var client = (program.socket && program.socket.host)
+  ? jayson.client.tcp(program.socket)
+  : jayson.client.http(program.url || program.socket);
 
 std.out.noise(
   colorize('magenta', '-> %s(%s)'),
@@ -65,6 +68,12 @@ client.request(program.method, program.params, function(err, response) {
 });
 
 function parseSocket(value) {
+  var addr = value.split(":");
+
+  if (addr.length == 2 && (net.isIP(addr[0]) || addr[0].toLowerCase() == "localhost")) {
+    return {port: addr[1], host: addr[0]};
+  }
+
   return {socketPath: path.normalize(value)};
 }
 

--- a/bin/jayson.js
+++ b/bin/jayson.js
@@ -37,7 +37,7 @@ var std = {
 };
 
 // do we have all arguments required to do something?
-if(!(program.method && program.params && (program.url || program.socket))) {
+if(!(program.method && (program.url || program.socket))) {
   std.err.result(program.helpInformation());
   return process.exit(-1);
 }

--- a/test/bin.server-client.test.js
+++ b/test/bin.server-client.test.js
@@ -10,7 +10,7 @@ describe('Jayson.Bin', function() {
 
   var server = jayson.server(support.server.methods, support.server.options);;
 
-  describe('port-listening server', function() {
+  describe('port-listening http server', function() {
 
     var http = null;
     var hostname = 'localhost';
@@ -58,7 +58,49 @@ describe('Jayson.Bin', function() {
 
   });
 
-  describe('socket-listening server', function() {
+  describe('port-listening tcp server', function() {
+
+    var tcp = null;
+    var hostname = 'localhost';
+    var port = "35000";
+    var socket = hostname + ":" + port;
+
+    before(function(done) {
+      tcp = server.tcp();
+      tcp.listen(port, hostname, done);
+    });
+
+    after(function(done) {
+      tcp.on('close', done);
+      tcp.close();
+    });
+
+    it('should be callable', function(done) {
+
+      var args = get_args(bin, {
+        socket: socket,
+        method: 'add',
+        quiet: true,
+        json: true,
+        params: JSON.stringify([1, 2])
+      });
+
+      exec(args, function(err, stdout, stderr) {
+        if(err) throw err;
+        var json = JSON.parse(stdout);
+        stderr.should.equal('');
+
+        json.should.containDeep({
+          result: 1 + 2
+        });
+
+        done();
+      });
+    });
+
+  });
+
+  describe('unix domain socket-listening server', function() {
 
     var http = null;
     var socketPath = __dirname + '/support/bin.test.socket';


### PR DESCRIPTION
I've added support for TCP sockets in the CLI using the same -s [socket] parameter. It now accepts either UDS (file like format) or a socket address (ip:port). I've also updated the CLI tests. Addresses issue #42 