### PR TITLE
handling invalid params passed as array; moving to Method.prototype.execute

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -121,8 +121,16 @@ Method.prototype.execute = function(server, params, callback) {
 
     args = args.concat(callback);
 
-    return handler.apply(server, args);
-  
+    if (args.length != handler.length) {
+
+      callback(server.error(jayson.server.errors.INVALID_PARAMS));
+
+    } else {
+
+      return handler.apply(server, args);
+      
+    }
+
   }
 
 };


### PR DESCRIPTION
This change will allow the new collect feature in 1.2 to do its thing with variable params, will allow named params to be variable, but for unnamed array-passed params will return an error instead of blowing up.