### PR TITLE
fix Utils.parseStream in a long connection, legacy issue #41

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,7 +109,7 @@ Utils.merge = function(a, b){
 
 Utils.parseStream = function(stream, options, onRequest) {
 
-  onRequest = _.once(onRequest);
+  var onError = _.once(onRequest);
 
   var result = JSONStream.parse();
 
@@ -124,7 +124,7 @@ Utils.parseStream = function(stream, options, onRequest) {
   });
 
   result.on('error', function(err) {
-    onRequest(err);
+    onError(err);
   });
 
   stream.pipe(result);


### PR DESCRIPTION
@tedeh Hi, I notice you have added `onRequest = _.once(onRequest)`. It will cause error, if I send more than one stream in a long connection, because the `onRequest` only triggered once on stream data event, streams except the first will never response. But the `onRequest` should not be triggered more than once on stream error event.