### PR TITLE
deps: upgrade JSONStream@0.8 to jsonstream@1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     }
   },
   "dependencies": {
-    "JSONStream": "0.8.0",
     "commander": "1.3.2",
     "eyes": "0.1.8",
+    "jsonstream": "^1.0.3",
     "lodash": "3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There are a lot of problems with JSONStream vs. jsonstream due to
case-folding and case-insensitive filesystems and how npm's cache
works. The best way forward is for everyone to standardize on
jsonstream, which is the canonical name for the module formerly called
JSONStream.