### PR TITLE
deps: upgrade JSONStream@0.8 to jsonstream@1

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var JSONStream = require('JSONStream');
+var JSONStream = require('jsonstream');
 
 /** * @namespace */
 var Utils = module.exports;

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     }
   },
   "dependencies": {
-    "JSONStream": "0.8.0",
     "commander": "1.3.2",
     "eyes": "0.1.8",
+    "jsonstream": "1.0.3",
     "lodash": "3.6.0"
   },
   "devDependencies": {

--- a/test/tcp.client-server.test.js
+++ b/test/tcp.client-server.test.js
@@ -4,7 +4,7 @@ var support = require(__dirname + '/support');
 var common = support.common;
 var net = require('net');
 var url = require('url');
-var JSONStream = require('JSONStream');
+var JSONStream = require('jsonstream');
 
 describe('Jayson.Tcp', function() {
 

--- a/test/tls.client-server.test.js
+++ b/test/tls.client-server.test.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var jayson = require(__dirname + '/..');
 var support = require('./support');
 var common = support.common;
-var JSONStream = require('JSONStream');
+var JSONStream = require('jsonstream');
 var tls = require('tls');
 
 var serverOptions = {


### PR DESCRIPTION
There are a lot of problems with JSONStream vs. jsonstream due to
case-folding and case-insensitive filesystems and how npm's cache
works. The best way forward is for everyone to standardize on
jsonstream, which is the canonical name for the module formerly called
JSONStream.

Replacement for #52 