### PR TITLE
Replace jsonstream with JSONStream

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var JSONStream = require('jsonstream');
+var JSONStream = require('JSONStream');
 
 /** * @namespace */
 var Utils = module.exports;

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     }
   },
   "dependencies": {
+    "JSONStream": "1.0.3",
     "commander": "1.3.2",
     "eyes": "0.1.8",
-    "jsonstream": "1.0.3",
     "lodash": "3.6.0"
   },
   "devDependencies": {

--- a/test/tcp.client-server.test.js
+++ b/test/tcp.client-server.test.js
@@ -5,7 +5,7 @@ var support = require(__dirname + '/support');
 var common = support.common;
 var net = require('net');
 var url = require('url');
-var JSONStream = require('jsonstream');
+var JSONStream = require('JSONStream');
 
 describe('Jayson.Tcp', function() {
 

--- a/test/tls.client-server.test.js
+++ b/test/tls.client-server.test.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var jayson = require(__dirname + '/..');
 var support = require('./support');
 var common = support.common;
-var JSONStream = require('jsonstream');
+var JSONStream = require('JSONStream');
 var tls = require('tls');
 
 var serverOptions = {


### PR DESCRIPTION
After much digging around it seems that the change in npm that
originally forced @dominictarr to publish JSONStream as jsonstream has
been fixed and thus the jsonstream package has been deprecated.

See:
 - npm/npm#7260
 - npm/npm#7195
 - dominictarr/JSONStream@31a4975

This partially reverts commit 79271de039c9562904d37fc8983b23a82464a708

resubmission of #56 