### PR TITLE
Upgrade jsonstream@1.0.3 to JSONStream@1.0.6

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var JSONStream = require('jsonstream');
+var JSONStream = require('JSONStream');
 
 /** * @namespace */
 var Utils = module.exports;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "commander": "1.3.2",
     "eyes": "0.1.8",
-    "jsonstream": "1.0.3",
+    "JSONStream": "1.0.6",
     "lodash": "3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Package [`jsonstream`](https://www.npmjs.com/package/jsonstream) has been deprecated and moved to [`JSONStream`](https://www.npmjs.com/package/JSONStream). The current version is 1.0.6.

When installed with `JSONStream@1.0.6` all tests are passing.