### PR TITLE
add delimiter to tcp client

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,19 @@ to pass a string URL as the first argument and have it interpreted by [url.parse
 
 ##### Client.tcp
 
-Uses the same options as the base class.
+Uses the same options as the base class in addition to these options:
+
+* `delimiter` -> String that determines the message delimiter to used on server as pipeline splitter marker. Example:
+
+```javascript
+var client = jayson.client.tcp({
+  delimiter : '\r\n',
+  host: 'localhost',
+  port: 3001
+});
+// now server will be get numder of commands as {object}\r\n{object}... sequence.
+
+```
 
 ##### Client.tls
 

--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -61,7 +61,9 @@ TcpClient.prototype._request = function(request, callback) {
         });
 
         conn.write(body);
-      
+        // if server require delimiters in pipeline
+        if(options.delimiter != null) conn.write(options.delimiter);
+
       }
 
     });

--- a/test/tcp.client-server.test.js
+++ b/test/tcp.client-server.test.js
@@ -105,6 +105,33 @@ describe('Jayson.Tcp', function() {
 
     describe('common tests', common(client));
 
+    it('should support delimiter option', function(done) {
+
+      var delimiter = '\r\n';
+
+      var client = jayson.client.tcp({
+        delimiter : delimiter,
+        host: 'localhost',
+        port: 3001
+      });
+
+      var server = net.createServer(function(connection){
+        connection.setEncoding('utf8');
+
+        connection.on('data', function(data){
+          data.should.endWith(delimiter);
+          server.close();
+          done();
+        });
+
+      });
+
+      server.listen(3001, 'localhost', function(){
+        client.request('foo', ['bar', 'baz'], function(){});
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
`delimiter` option may be used in case of server requirement to have some
separator of commands in one connection.