### PR TITLE
Support scope for server method call

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,12 +70,13 @@ Client.tls = require('./client/tls');
  *  @param {String|Array} method A batch request if passed an Array, or a method name if passed a String
  *  @param {Array|Object} params Parameters for the method
  *  @param {String|Number} [id] Optional id. If undefined an id will be generated. If null it creates a notification request
+ *  @param {Object} [options] The options for sub client
  *  @param {Function} [callback] Request callback. If specified, executes the request rather than only returning it.
  *  @throws {TypeError} Invalid parameters
  *  @return {Object} JSON-RPC 1.0 or 2.0 compatible request
  *  @api public
  */
-Client.prototype.request = function(method, params, id, callback) {
+Client.prototype.request = function(method, params, id, options, callback) {
   var self = this;
 
   // is this a batch request?
@@ -93,9 +94,22 @@ Client.prototype.request = function(method, params, id, callback) {
     callback = params;
     request = method;
   } else {
-    if(typeof(id) === 'function') {
+    if(typeof id === 'function') {
       callback = id;
+      options = undefined;
       id = undefined; // specifically undefined because "null" is a notification request
+    } else if (id && typeof id === 'object') { // null is object
+      callback = options;
+      options = id;
+      id = undefined;
+    }
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+
+    if (id === undefined && options) {
+      id = options.id;
     }
 
     var hasCallback = typeof(callback) === 'function';
@@ -118,10 +132,16 @@ Client.prototype.request = function(method, params, id, callback) {
 
   this.emit('request', request);
 
-  this._request(request, function(err, response) {
+  function done(err, response) {
     self.emit('response', request, response);
     self._parseResponse(err, response, callback);
-  });
+  }
+
+  if (this._request.length < 3) {
+    this._request(request, done);
+  } else {
+    this._request(request, options, done);
+  }
 
   // always return the raw request
   return request;

--- a/lib/method.js
+++ b/lib/method.js
@@ -60,6 +60,7 @@ Method.prototype.execute = function(server, params, callback) {
 
   var handler = this.getHandler();
   var options = this.options;
+  var scope = options.scope || server;
 
   var callParams = null;
   var objectParams = !_.isArray(params) && _.isObject(params) && params;
@@ -98,7 +99,7 @@ Method.prototype.execute = function(server, params, callback) {
     
     }
 
-    return handler.call(server, callParams, callback);
+    return handler.call(scope, callParams, callback);
 
   } else {
 
@@ -125,7 +126,7 @@ Method.prototype.execute = function(server, params, callback) {
     if (callParams.length != handler.length) {
       return callback(server.error(jayson.Server.errors.INVALID_PARAMS));
     } else {
-      return handler.apply(server, callParams);
+      return handler.apply(scope, callParams);
     }
 
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,7 @@ var utils = require('./utils');
  *  @param {String} [options.encoding="utf8"] Encoding to use
  *  @param {Number} [options.version=2] JSON-RPC version to use (1|2)
  *  @param {Function} [options.router] Function to use for routing methods
+ *  @param {Function} [options.scope] The scope of server's methods, can be override by method scope options
  *  @property {Object} options A reference to the internal options object that can be modified directly
  *  @property {Object} errorMessages Map of error code to error message pairs that will be used in server responses
  *  @property {ServerHttp} http HTTP interface constructor
@@ -112,10 +113,11 @@ Server.errorMessages[Server.errors.INTERNAL_ERROR] = 'Internal error';
  *  Adds a single method to the server
  *  @param {String} name Name of method to add
  *  @param {Function|Client} definition Function or Client for a relayed method
+ *  @param {Object} [scope] The scope of method
  *  @throws {TypeError} Invalid parameters
  *  @api public
  */
-Server.prototype.method = function(name, definition) {
+Server.prototype.method = function(name, definition, scope) {
 
   var isRelay = definition instanceof jayson.Client;
   var isMethod = definition instanceof jayson.Method;
@@ -138,7 +140,8 @@ Server.prototype.method = function(name, definition) {
   if(!isRelay && !isMethod) {
     definition = new jayson.Method(definition, {
       collect: this.options.collect,
-      params: this.options.params
+      params: this.options.params,
+      scope: scope || this.options.scope
     });
   }
 
@@ -148,13 +151,14 @@ Server.prototype.method = function(name, definition) {
 /**
  *  Adds a batch of methods to the server
  *  @param {Object} methods Methods to add
+ *  @param {Object} [scope] The scope of methods
  *  @api public
  */
-Server.prototype.methods = function(methods) {
+Server.prototype.methods = function(methods, scope) {
   methods = methods || {};
 
   for(var name in methods) {
-    this.method(name, methods[name]);
+    this.method(name, methods[name], scope);
   }
 
 };

--- a/test/method.test.js
+++ b/test/method.test.js
@@ -287,6 +287,32 @@ describe('Jayson.Method', function() {
         });
       
       });
+
+      describe('options.scope provided', function() {
+
+        var scope = {
+          message: 'Hello, '
+        };
+
+        var fn = function(name, callback) {
+          callback(null, this.message + name);
+        };
+
+        beforeEach(function() {
+          method = new Method(fn, {
+            scope: scope
+          });
+        });
+
+        it('should call with scope', function(done) {
+          method.execute(server, {name: 'Jayson'}, function(err, result) {
+            if(err) throw err;
+            result.should.eql('Hello, Jayson');
+            done();
+          });
+        });
+
+      });
     
     });
   

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -36,11 +36,12 @@ describe('Jayson.Server', function() {
     it('should pass options collect and params as defaults to jayson.Method', function() {
       server.options.collect = true;
       server.options.params = Object;
+      server.options.scope = Object;
       server.method('add', function(args, done) {
         done();
       });
       server.getMethod('add').should.containDeep({
-        options: {collect: true, params: Object}
+        options: {collect: true, params: Object, scope: Object}
       });
     });
 


### PR DESCRIPTION
Example:
```js
function Service() {
  this.state = false
}

Service.prototype.set = function (state) {
  this.state = state;
}
...
var service = new Service();
server.method('set', service.set, service); // The third parameter is the scope
```