### PR TITLE
Handle circular references without throwing an exception

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var JSONStream = require('JSONStream');
+var JSONstringify = require('json-stringify-safe');
 
 /** * @namespace */
 var Utils = module.exports;
@@ -41,7 +42,7 @@ Utils.request = function(method, params, id, options) {
     }
 
     request.params = params;
-  
+
   }
 
   // if id was left out, generate one (null means explicit notification)
@@ -51,7 +52,7 @@ Utils.request = function(method, params, id, options) {
   } else {
     request.id = id;
   }
-  
+
   return request;
 };
 
@@ -293,7 +294,7 @@ Utils.JSON.stringify = function(obj, options, callback) {
   }
 
   try {
-    var str = JSON.stringify.apply(JSON, _.compact([obj, replacer]));
+    var str = JSONstringify.apply(JSON, _.compact([obj, replacer]));
   } catch(err) {
     return callback(err);
   }
@@ -431,7 +432,7 @@ Utils.Response.isValidError = function(error, version) {
       typeof(error) !== 'undefined'
       && error !== null
     )
-    || version === 2 && ( 
+    || version === 2 && (
       error
       && typeof(error.code) === 'number'
       && parseInt(error.code) == error.code

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "JSONStream": "1.0.3",
     "commander": "1.3.2",
     "eyes": "0.1.8",
+    "json-stringify-safe": "^5.0.1",
     "lodash": "3.6.0"
   },
   "devDependencies": {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -61,7 +61,7 @@ describe('Jayson.Utils', function() {
     });
 
     it('should return the correct names when passed a odd-formatted function', function() {
-      var func = function     (a, b            , __b) { 
+      var func = function     (a, b            , __b) {
         func(2, 3, 55, 4);
         return a + b;
       };
@@ -151,7 +151,25 @@ describe('Jayson.Utils', function() {
 
       stream.end("\"");
     });
-  
+
+  });
+
+  describe('stringify', function(done) {
+
+    it('should not throw with circular JSON reference', function(done) {
+
+      var foo = {};
+      var bar = { foo: foo };
+      foo.bar = bar;
+
+      var fn = utils.JSON.stringify(bar, {}, function(err, str) {
+        should(err).not.exist;
+        done();
+      });
+
+      should(fn).not.throw();
+    });
+
   });
 
 });


### PR DESCRIPTION
Apologies for the whitespace that has been removed, dirtying the diff.

Fixes #66 