### PR TITLE
Allow for empty params when collect: false is used.

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -120,6 +120,12 @@ Method.prototype.execute = function(server, requestParams, callback) {
     return handler.call(server, params, callback);
   }
 
+  // Params is optional according to the JSON-RPC 2.0 spec so if it doesnt
+  // exist create an empty array.
+  if (!params) {
+    params = [];
+  }
+
   // compare without the callback
   if(handler.length !== (params.length + 1)) {
     callback(server.error(jayson.Server.errors.INVALID_PARAMS));


### PR DESCRIPTION
Fixes #71 