### PR TITLE
Make getParameterNames work with ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Servers supports these options:
 | `params`            	| `undefined`     	| `Array|Object|null` 	| Passed to `methodConstructor` options                     	|
 | `methodConstructor` 	| `jayson.Method` 	| `Function`          	| Server functions are made an instance of this class       	|
 | `version`           	| 2               	| `Number`            	| JSON-RPC version to support (1 or 2)                      	|
+| `noUndefinedArgs`     | `false`           | `Boolean`             | Client must provide all method arguments in request object  |
 
 ##### Server.tcp
 

--- a/lib/method.js
+++ b/lib/method.js
@@ -95,13 +95,19 @@ Method.prototype._getHandlerParams = function(params) {
 
     if(isObjectParams) {
       // named parameters passed, take all parameters for handler except last (the callback)
-      // and place them in an array. If any parameters are undefined, remove them from the
-      // array so RPC will return an invalid params error
-      return _.initial(utils.getParameterNames(handler)).map(function(name) {
+      // and place them in an array. 
+      
+      // If noUndefinedArgs option is specified, remove any parameters that are undefined, 
+      // from the array so RPC will return an invalid params error
+      var arrayParams = _.initial(utils.getParameterNames(handler)).map(function(name) {
         return params[name];
-      }).filter(function(value) {
-        return typeof value !== 'undefined'; 
       });
+      if (options.noUndefinedArgs) {
+        return arrayParams.filter(function(value) {
+          return typeof value !== 'undefined'; 
+        });
+      }
+      return arrayParams;
     }
 
     // regular parameters array passed

--- a/lib/method.js
+++ b/lib/method.js
@@ -95,8 +95,12 @@ Method.prototype._getHandlerParams = function(params) {
 
     if(isObjectParams) {
       // named parameters passed, take all parameters for handler except last (the callback)
+      // and place them in an array. If any parameters are undefined, remove them from the
+      // array so RPC will return an invalid params error
       return _.initial(utils.getParameterNames(handler)).map(function(name) {
         return params[name];
+      }).filter(function(value) {
+        return typeof value !== 'undefined'; 
       });
     }
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -32,6 +32,7 @@ var Server = function(methods, options) {
   }
 
   var defaults = {
+    noUndefinedArgs: false,
     reviver: null,
     replacer: null,
     encoding: 'utf8',
@@ -138,6 +139,7 @@ Server.prototype.method = function(name, definition) {
   // make instance of jayson.Method
   if(!isRelay && !isMethod) {
     definition = new Method(definition, {
+      noUndefinedArgs: this.options.noUndefinedArgs,
       collect: this.options.collect,
       params: this.options.params
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -252,7 +252,7 @@ Utils.isMethod = function(request, method) {
 Utils.getParameterNames = function(func) {
   if(typeof(func) !== 'function') return [];
   var body = func.toString();
-  var args = /^function .*?\((.+?)\)/.exec(body);
+  var args = /^(?:function )*.*?\((.+?)\)/.exec(body);
   if(!args) return [];
   var list = (args.pop() || '').split(',');
   return list.map(function(arg) { return arg.trim(); });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -46,14 +46,15 @@ describe('Jayson.Server', function() {
       server.getMethod('add').should.be.instanceof(ctor);
     });
 
-    it('should pass options collect and params as defaults to jayson.Method', function() {
+    it('should pass options collect, params, noUndefinedArgs as defaults to jayson.Method', function() {
       server.options.collect = true;
       server.options.params = Object;
+      server.options.noUndefinedArgs = true;
       server.method('add', function(args, done) {
         done();
       });
       server.getMethod('add').should.containDeep({
-        options: {collect: true, params: Object}
+        options: {collect: true, params: Object, noUndefinedArgs: true}
       });
     });
 
@@ -386,15 +387,26 @@ describe('Jayson.Server', function() {
         });
       });
 
-      it('should fail when not given sufficient arguments', function(done) {
+      it('should pass when not given sufficient arguments', function(done) {
         var request = utils.request('add', {});
+        server.call(request, function(err, response) {
+          if (err) return done(err);
+          isNaN(response.result).should.equal(true);
+          done();
+        });
+      });
+      
+      it('should fail when noUndefinedArgs set and not given sufficient arguments', function(done) {
+        var request = utils.request('add', {});
+        var serverOptions = support.server.options;
+        serverOptions.noUndefinedArgs = true;
+        server = Server(support.server.methods, support.server.options);
         server.call(request, function(err, response) {
           should.not.exist(response);
           err.should.containDeep({error: {code: ServerErrors.INVALID_PARAMS}});
           done();
         });
       });
-
     });
 
     describe('notification requests', function() {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -386,11 +386,11 @@ describe('Jayson.Server', function() {
         });
       });
 
-      it('should not fail when not given sufficient arguments', function(done) {
+      it('should fail when not given sufficient arguments', function(done) {
         var request = utils.request('add', {});
         server.call(request, function(err, response) {
-          if(err) return done(err);
-          isNaN(response.result).should.equal(true);
+          should.not.exist(response);
+          err.should.containDeep({error: {code: ServerErrors.INVALID_PARAMS}});
           done();
         });
       });


### PR DESCRIPTION
ES6's toString function returns something like

    (x, y) => { ...

not

    function(x, y) { ...