### PR TITLE
Add CORS support

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -173,16 +173,37 @@ Utils.getHttpListener = function(self, server) {
     var options = self.options || {};
 
     server.emit('http request', req);
+    
+    var origin = req.headers['origin'] || '*';
+    if (Utils.isMethod(req, "OPTIONS")) {
+        if (req.headers['origin']) {
+            var method = (req.headers['access-control-request-method'] || '').toUpperCase();
+            if (method !== 'POST')
+                return respondError('CORS Method not allowed', 405, { 'allow': 'POST' });
+
+            res.writeHead(
+                "204",
+                "No Content",
+                {
+                    "access-control-allow-origin": origin,
+                    "access-control-allow-methods": "POST, OPTIONS",
+                    "access-control-allow-headers": "content-type, accept",
+                    "access-control-max-age": 10, // Seconds.
+                    "content-length": 0
+                }
+            );
+
+            return res.end();
+        }
+    }
 
     //  405 method not allowed if not POST
-    if(!Utils.isMethod(req, 'POST')) {
-      return respond('Method Not Allowed', 405, {'allow': 'POST'});
-    }
+    
+    //  405 method not allowed if not POST
+    if(!Utils.isMethod(req, 'POST')) return respondError('Method not allowed', 405, { 'allow': 'POST', 'access-control-allow-origin' : origin });
 
-    // 415 unsupported media type if Content-Type is not correct
-    if(!Utils.isContentType(req, 'application/json')) {
-      return respond('Unsupported Media Type', 415);
-    }
+    // 415 unsupported media type if content-type is not correct
+    if(!Utils.isContentType(req, 'application/json')) return respondError('Unsupported media type', 415, {'access-control-allow-origin' : origin});
 
     Utils.parseBody(req, options, function(err, request) {
       if(err) return respond(err, 500);
@@ -195,11 +216,12 @@ Utils.getHttpListener = function(self, server) {
         }
 
         utils.JSON.stringify(response, options, function(err, body) {
-          if(err) return respond(err, 500);
+          if(err) return respondError(err, 500, {'access-control-allow-origin' : origin});
 
           var headers = {
             'content-length': Buffer.byteLength(body, options.encoding),
-            'content-type': 'application/json; charset=utf-8'
+            'content-type': 'application/json; charset=utf-8',
+            "access-control-allow-origin" : origin
           };
 
           respond(body, 200, headers);
@@ -252,7 +274,7 @@ Utils.isMethod = function(request, method) {
 Utils.getParameterNames = function(func) {
   if(typeof(func) !== 'function') return [];
   var body = func.toString();
-  var args = /^(?:function )*.*?\((.+?)\)/.exec(body);
+  var args = /^function .*?\((.+?)\)/.exec(body);
   if(!args) return [];
   var list = (args.pop() || '').split(',');
   return list.map(function(arg) { return arg.trim(); });
@@ -433,7 +455,7 @@ Utils.Response.isValidError = function(error, version) {
     || version === 2 && (
       error
       && typeof(error.code) === 'number'
-      && parseInt(error.code, 10) === error.code
+      && parseInt(error.code) == error.code
       && typeof(error.message) === 'string'
     )
   );


### PR DESCRIPTION
Why not just support CORS directly? It's obviously a highly common usage case to account for, and just a few lines of code add support automatically.