### PR TITLE
Allow function arguments to span lines

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -266,7 +266,7 @@ Utils.getParameterNames = function(func) {
     return [];
   }
 
-  var body = func.toString();
+  var body = func.toString().replace(/[\n\r]/g, " ");
   var args = /^(?:function )*.*?\((.+?)\)/.exec(body);
   if(!args) {
     return [];

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -72,6 +72,20 @@ describe('jayson.utils', function() {
       result.should.containDeep(['a', 'b', '__b']);
     });
 
+    it('should return the correct names when passed multi-line arguments', function() {
+      var func = function (
+        a,
+        b , __b) {
+        func(2, 3, 55, 4);
+        return a + b;
+      };
+      var result = utils.getParameterNames(func);
+      should.exist(result);
+      result.should.be.instanceof(Array);
+      result.should.have.length(func.length);
+      result.should.containDeep(['a', 'b', '__b']);
+    });
+
     it('should return the correct names when passed a function with complex parameters', function() {
       var func = function(_$foo, $$, FOO, $F00, _) { return false; };
       var result = utils.getParameterNames(func);


### PR DESCRIPTION
The `getParameterNames` function expects to find all arguments to method definitions on a single line. This is not always the case, however. Arguments may be all on one line, may be one per line, or may just be divided onto a few lines to meet line-length desires.

This patch replaces newlines and carriage returns in the function body, each with a single space, so that the arguments can be extracted easily regardless of how they were laid out by the method implementer.
