### PR TITLE
Option to enable or disable serialization

### DIFF
--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -11,6 +11,7 @@ var generateRequest = require('../generateRequest');
  *  @param {Function} [options.replacer] Replacer function for JSON
  *  @param {Number} [options.version=2] JSON-RPC version to use (1|2)
  *  @param {Function} [options.generator] Function to use for generating request IDs
+ *  @param {Boolean} [options.serialization] Option to enable or disable serialization and deserialization
  *  @return {ClientBrowser}
  */
 var ClientBrowser = function(callServer, options) {
@@ -22,7 +23,8 @@ var ClientBrowser = function(callServer, options) {
     reviver: null,
     replacer: null,
     generator: function() { return uuid(); },
-    version: 2
+    version: 2,
+    serialization: true
   };
 
   this.options = _.extend(defaults, options || {});
@@ -86,10 +88,14 @@ ClientBrowser.prototype.request = function(method, params, id, callback) {
   }
 
   var message;
-  try {
-    message = JSON.stringify(request, this.options.replacer);
-  } catch(err) {
-    return callback(err);
+  if (this.options.serialization === true) {
+      try {
+          message = JSON.stringify(request, this.options.replacer);
+      } catch (err) {
+          return callback(err);
+      }
+  } else {
+      message = request;
   }
 
   this.callServer(message, function(err, response) {
@@ -117,10 +123,14 @@ ClientBrowser.prototype._parseResponse = function(err, responseText, callback) {
   }
 
   var response;
-  try {
-    response = JSON.parse(responseText, this.options.reviver);
-  } catch(err) {
-    return callback(err);
+  if (this.options.serialization === true) {
+      try {
+          response = JSON.parse(responseText, this.options.reviver);
+      } catch (err) {
+          return callback(err);
+      }
+  } else {
+    response = responseText;
   }
 
   if(callback.length === 3) {


### PR DESCRIPTION
With third-party transport, such as socket.io, serialization and deserialization can already be built into.