### PR TITLE
Fixes delimiter to use newline for TCP client

### DIFF
--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -53,7 +53,7 @@ ClientTcp.prototype._request = function(request, callback) {
       if(utils.Request.isNotification(request)) {
 
         handled = true;
-        conn.end(body);
+        conn.end(body + '\n');
         callback();
 
       } else {
@@ -67,8 +67,8 @@ ClientTcp.prototype._request = function(request, callback) {
           callback(null, response);
         });
 
-        conn.write(body);
-      
+        conn.write(body + '\n');
+
       }
 
     });


### PR DESCRIPTION
Specifically, rust's jsonrpc did not work correctly without a delimiter, and newline seems like a very sane default. See: https://github.com/paritytech/jsonrpc/issues/162#issuecomment-312561911

There is a simple [fix](https://paritytech.github.io/jsonrpc/jsonrpc_tcp_server/struct.ServerBuilder.html#method.request_separators) for it in that library. [This](https://kodi.wiki/view/JSON-RPC_API#TCP) reference and the spec agree that it could/should be done by waiting until it's valid json, but this seems unintuitive to a user of this library (eg it took me a bit to realize why my requests were not working).

Happy to drop this PR if an extra byte is too much, or if the library prefers to be to-spec (afaik this won't cause any issues, but it does alter behavior a tiny bit).