### PR TITLE
fix: write newline also to TLS socket

### DIFF
--- a/lib/client/tls.js
+++ b/lib/client/tls.js
@@ -53,7 +53,7 @@ ClientTls.prototype._request = function(request, callback) {
       if(utils.Request.isNotification(request)) {
 
         handled = true;
-        conn.end(body);
+        conn.end(body + '\n');
         callback();
 
       } else {
@@ -67,7 +67,7 @@ ClientTls.prototype._request = function(request, callback) {
           callback(null, response);
         });
 
-        conn.write(body);
+        conn.write(body + '\n');
       
       }
 


### PR DESCRIPTION
`/lib/client/tcp.js` client already did this correctly. It was simply missing in TLS implementation, leading to the situation where TLS clients would not get responses, as servers would still be waiting for request to be finished, which never happens.