### PR TITLE
Append newlines to TCP/TLS server writes to match clients

### DIFF
--- a/lib/server/tcp.js
+++ b/lib/server/tcp.js
@@ -46,7 +46,7 @@ function getTcpListener(self, server) {
             if(err) {
               return respondError(err);
             }
-            conn.write(body);
+            conn.write(body + '\n');
           });
         } else {
           // no response received at all, must be a notification
@@ -63,7 +63,7 @@ function getTcpListener(self, server) {
         if(err) {
           body = ''; // we tried our best.
         }
-        conn.end(body);
+        conn.end(body + '\n');
       });
     }
 

--- a/lib/server/tls.js
+++ b/lib/server/tls.js
@@ -46,7 +46,7 @@ function getTlsListener(self, server) {
             if(err) {
               return respondError(err);
             }
-            conn.write(body);
+            conn.write(body + '\n');
           });
         } else {
           // no response received at all, must be a notification
@@ -63,7 +63,7 @@ function getTlsListener(self, server) {
         if(err) {
           body = ''; // we tried our best.
         }
-        conn.end(body);
+        conn.end(body + '\n');
       });
     }
 


### PR DESCRIPTION
Hi, I'm starting to use this library as a TCP client & server and noticed the server responses didn't have newlines on them. Looks like it was decided previously to use them on the client and it would be great if the server acted the same. [PR 114](https://github.com/tedeh/jayson/pull/114)

I'm not using the TLS version but noticed [this PR](https://github.com/tedeh/jayson/pull/123) was very similar to the TCP situation so I went ahead and updated the TLS server as well.

Thanks for your work on this.