### PR TITLE
Allow for a delimiter option for tcp client

### DIFF
--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -39,6 +39,7 @@ ClientTcp.prototype._request = function(request, callback) {
 
   // copies options so object can be modified in this context
   const options = utils.merge({}, this.options);
+  const delimiter = options.delimiter || '\n'
 
   utils.JSON.stringify(request, options, function(err, body) {
     if(err) {
@@ -55,7 +56,7 @@ ClientTcp.prototype._request = function(request, callback) {
       if(utils.Request.isNotification(request)) {
 
         handled = true;
-        conn.end(body + '\n');
+        conn.end(body + delimiter);
         callback();
 
       } else {
@@ -69,7 +70,7 @@ ClientTcp.prototype._request = function(request, callback) {
           callback(null, response);
         });
 
-        conn.write(body + '\n');
+        conn.write(body + delimiter);
 
       }
 

--- a/lib/client/tcp.js
+++ b/lib/client/tcp.js
@@ -39,7 +39,7 @@ ClientTcp.prototype._request = function(request, callback) {
 
   // copies options so object can be modified in this context
   const options = utils.merge({}, this.options);
-  const delimiter = options.delimiter || '\n'
+  const delimiter = options.delimiter || '\n';
 
   utils.JSON.stringify(request, options, function(err, body) {
     if(err) {

--- a/test/tcp.client-server.test.js
+++ b/test/tcp.client-server.test.js
@@ -93,7 +93,8 @@ describe('jayson.tcp', function() {
       reviver: support.server.options().reviver,
       replacer: support.server.options().replacer,
       host: 'localhost',
-      port: 3999
+      port: 3999,
+      delimiter: '\r\n'
     });
 
     before(function(done) {


### PR DESCRIPTION
I recently used this library in a project, but the server required a TCP connection with a delimiter of '\r\n'. I figured it would be useful to include an option to specify this.