### PR TITLE
Updated lodash imports to better support tree shaking for webpack and bundlers

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const _ = require('lodash');
-const utils = require('../utils');
 const events = require('events');
+const isPlainObject = require('lodash/isPlainObject');
+
+const utils = require('../utils');
 
 /**
  *  Constructor for a Jayson Client
@@ -17,7 +18,7 @@ const events = require('events');
  *  @return {Client}
  */
 const Client = function(server, options) {
-  if(arguments.length === 1 && _.isPlainObject(server)) {
+  if(arguments.length === 1 && isPlainObject(server)) {
     options = server;
     server = null;
   }

--- a/lib/method.js
+++ b/lib/method.js
@@ -1,7 +1,16 @@
 'use strict';
 
+const isArray = require('lodash/isArray');
+const isPlainObject = require('lodash/isPlainObject');
+const isObject = require('lodash/isObject');
+const extend = require('lodash/extend');
+const keys = require('lodash/keys');
+const reduce = require('lodash/reduce');
+const pick = require('lodash/pick');
+const toArray = require('lodash/toArray');
+const toPlainObject = require('lodash/toPlainObject');
+
 const utils = require('./utils');
-const _ = require('lodash');
 
 /**
  * @summary Constructor for a Jayson Method
@@ -19,7 +28,7 @@ const Method = function(handler, options) {
   }
 
   // only got passed options
-  if(_.isPlainObject(handler)) {
+  if(isPlainObject(handler)) {
     options = handler;
     handler = null;
   }
@@ -59,31 +68,31 @@ Method.prototype.setHandler = function(handler) {
 Method.prototype._getHandlerParams = function(params) {
   const options = this.options;
 
-  const isObjectParams = !_.isArray(params) && _.isObject(params) && params;
-  const isArrayParams = _.isArray(params);
+  const isObjectParams = !isArray(params) && isObject(params) && params;
+  const isArrayParams = isArray(params);
 
   switch(true) {
 
       // handler always gets an array
     case options.params === Array:
-      return isArrayParams ? params : _.toArray(params);
+      return isArrayParams ? params : toArray(params);
 
       // handler always gets an object
     case options.params === Object:
-      return isObjectParams ? params : _.toPlainObject(params);
+      return isObjectParams ? params : toPlainObject(params);
 
       // handler gets a list of defined properties that should always be set
-    case _.isArray(options.params): {
-      const undefinedParams = _.reduce(options.params, function(undefinedParams, key) {
+    case isArray(options.params): {
+      const undefinedParams = reduce(options.params, function(undefinedParams, key) {
         undefinedParams[key] = undefined;
         return undefinedParams;
       }, {});
-      return _.extend(undefinedParams, _.pick(params, _.keys(params)));
+      return extend(undefinedParams, pick(params, keys(params)));
     }
 
       // handler gets a map of defined properties and their default values
-    case _.isPlainObject(options.params):
-      return _.extend({}, options.params, _.pick(params, _.keys(params)));
+    case isPlainObject(options.params):
+      return extend({}, options.params, pick(params, keys(params)));
 
       // give params as is
     default:

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const jayson = require('../');
 const events = require('events');
-const _ = require('lodash');
+const isFunction = require('lodash/isFunction');
+const jayson = require('../');
 const utils = require('../utils');
 
 /**
@@ -122,10 +122,10 @@ Server.prototype.method = function(name, definition) {
 
   const isRelay = definition instanceof jayson.Client;
   const isMethod = definition instanceof Method;
-  const isFunction = _.isFunction(definition);
+  const isDefinitionFunction = isFunction(definition);
 
   // a valid method is either a function or a client (relayed method)
-  if(!isRelay && !isMethod && !isFunction) {
+  if(!isRelay && !isMethod && !isDefinitionFunction) {
     throw new TypeError('method definition must be either a function, an instance of jayson.Client or an instance of jayson.Method');
   }
 
@@ -216,7 +216,7 @@ Server.prototype.error = function(code, message, data) {
  *  Calls a method on the server
  *  @param {Object|Array|String} request A JSON-RPC request object. Object for single request, Array for batches and String for automatic parsing (using the reviver option)
  *  @param {Object} [context] Optional context object passed to methods
- *  @param {Function} [callback] Callback that receives one of two arguments: first is an error and the second a response 
+ *  @param {Function} [originalCallback] Callback that receives one of two arguments: first is an error and the second a response
  */
 Server.prototype.call = function(request, context, originalCallback) {
   const self = this;
@@ -342,7 +342,7 @@ Server.prototype._resolveRouter = function(method, params) {
 
   let router = this.options.router;
 
-  if(!_.isFunction(router)) {
+  if(!isFunction(router)) {
     router = function(method) {
       return this.getMethod(method);
     };
@@ -356,7 +356,7 @@ Server.prototype._resolveRouter = function(method, params) {
   }
 
   // got a regular function, make it an instance of jayson.Method
-  if(_.isFunction(resolved)) {
+  if(isFunction(resolved)) {
     return new jayson.Method(resolved);
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,14 @@
 'use strict';
 
-const _ = require('lodash');
+const compact = require('lodash/compact');
+const extend = require('lodash/extend');
+const isFunction = require('lodash/isFunction');
+const once = require('lodash/once');
+const partial = require('lodash/partial');
 const JSONStream = require('JSONStream');
 const JSONstringify = require('json-stringify-safe');
 const uuid = require('uuid/v4');
+
 const generateRequest = require('./generateRequest');
 
 /** * @namespace */
@@ -57,7 +62,7 @@ Utils.generateId = function() {
  *  @private
  */
 Utils.merge = function() {
-  return _.extend.apply(null, arguments);
+  return extend.apply(null, arguments);
 };
 
 /**
@@ -68,15 +73,15 @@ Utils.merge = function() {
  */
 Utils.parseStream = function(stream, options, onRequest) {
 
-  const onError = _.once(onRequest);
-  const onSuccess = _.partial(onRequest, null);
+  const onError = once(onRequest);
+  const onSuccess = partial(onRequest, null);
 
   const result = JSONStream.parse();
 
   result.on('data', function(data) {
 
     // apply reviver walk function to prevent stringify/parse again
-    if(_.isFunction(options.reviver)) {
+    if(isFunction(options.reviver)) {
       data = Utils.walk({'': data}, '', options.reviver);
     }
 
@@ -93,12 +98,12 @@ Utils.parseStream = function(stream, options, onRequest) {
 /**
  *  Helper to parse a stream and interpret it as JSON
  *  @param {Stream} stream Stream instance
- *  @param {Function} [reviver] Optional reviver for JSON.parse
+ *  @param {Function} [options] Optional options for JSON.parse
  *  @param {Function} callback
  */
 Utils.parseBody = function(stream, options, callback) {
 
-  callback = _.once(callback);
+  callback = once(callback);
   let data = '';
 
   stream.setEncoding('utf8');
@@ -240,18 +245,19 @@ Utils.JSON = {};
  * Parses a JSON string and then invokes the given callback
  * @param {String} str The string to parse
  * @param {Object} options Object with options, possibly holding a "reviver" function
+ * @param {Function} callback
  */
 Utils.JSON.parse = function(str, options, callback) {
   let reviver = null;
   let obj = null;
   options = options || {};
 
-  if(_.isFunction(options.reviver)) {
+  if(isFunction(options.reviver)) {
     reviver = options.reviver;
   }
 
   try {
-    obj = JSON.parse.apply(JSON, _.compact([str, reviver]));
+    obj = JSON.parse.apply(JSON, compact([str, reviver]));
   } catch(err) {
     return callback(err);
   }
@@ -263,18 +269,19 @@ Utils.JSON.parse = function(str, options, callback) {
  * Stringifies JSON and then invokes the given callback
  * @param {Object} obj The object to stringify
  * @param {Object} options Object with options, possibly holding a "replacer" function
+ * @param {Function} callback
  */
 Utils.JSON.stringify = function(obj, options, callback) {
   let replacer = null;
   let str = null;
   options = options || {};
 
-  if(_.isFunction(options.replacer)) {
+  if(isFunction(options.replacer)) {
     replacer = options.replacer;
   }
 
   try {
-    str = JSONstringify.apply(JSON, _.compact([obj, replacer]));
+    str = JSONstringify.apply(JSON, compact([obj, replacer]));
   } catch(err) {
     return callback(err);
   }

--- a/promise/lib/method.js
+++ b/promise/lib/method.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const jayson = require('../../');
-const _ = require('lodash');
+const isFunction = require('lodash/isFunction');
 
 /**
  * Constructor for a Jayson Promise Method
@@ -24,6 +24,7 @@ module.exports = PromiseMethod;
  * @summary Executes this method in the context of a server
  * @param {Server} server
  * @param {Array|Object} requestParams
+ * @param {Object} [context] Optional context object passed to methods
  * @param {Function} outerCallback
  * @return {Promise}
  */
@@ -42,7 +43,7 @@ PromiseMethod.prototype.execute = function(server, requestParams, context, outer
     outerCallback.apply(null, arguments);
   });
 
-  wasPromised = promise && _.isFunction(promise.then);
+  wasPromised = promise && isFunction(promise.then);
 
   // if the handler returned a promise, call the callback when it resolves
   if(wasPromised) {


### PR DESCRIPTION
I've updated the require statements for lodash to allow for better webpack bundling and automatic tree shaking on version 4.0+. While I was modifying these files, I also updated missing jsdoc and fixed a few small lint errors.

I noticed that my bundle sizes were quite large due to full lodash imports and this has shaved off a significant amount of unused code during bundling (70 kb!).