### PR TITLE
Added context object to server side event emits

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,22 +763,22 @@ client.request('context', {hello: 'world'}, function(err, response) {
 
 In addition to events that are specific to certain interfaces, all servers will emit the following events:
 
-| Event      	| When                                     	| Arguments                            	| Notes                          	|
-|------------	|------------------------------------------	|--------------------------------------	|--------------------------------	|
-| `request`  	| Interpretable non-batch request received 	| 1: Request object                    	|                                	|
-| `response` 	| Returning a response                     	| 1: Request object 2: Response object 	|                                	|
-| `batch`    	| Interpretable batch request received     	| 1. Array of requests                 	| Emits `request` for every part 	|
+| Event      	| When                                     	| Arguments                            	                            | Notes                          	|
+|------------	|------------------------------------------	|------------------------------------------------------------------ |--------------------------------	|
+| `request`  	| Interpretable non-batch request received 	| 1: Request object <br/>2: Context object                          |                                	|
+| `response` 	| Returning a response                     	| 1: Request object <br/>2: Response object <br/>3: Context object  |                                	|
+| `batch`    	| Interpretable batch request received     	| 1. Array of requests  <br/>2: Context object                	    | Emits `request` for every part 	|
 
 #### Server Errors
 
 If you should like to return an error from an method request to indicate a failure, remember that the [JSON-RPC 2.0][jsonrpc-spec] specification requires the error to be an `Object` with a `code (Integer/Number)` to be regarded as valid. You can also provide a `message (String)` and a `data (Object)` with additional information. Example: 
 
 ```javascript
-var jayson = require('jayson');
+const jayson = require('jayson');
 
-var server = jayson.server({
+const server = jayson.server({
   i_cant_find_anything: function(args, callback) {
-    var error = {code: 404, message: 'Cannot find ' + args.id};
+    const error = {code: 404, message: 'Cannot find ' + args.id};
     callback(error); // will return the error object as given
   },
   i_cant_return_a_valid_error: function(callback) {
@@ -794,11 +794,11 @@ It is also possible to cause a method to return one of the predefined [JSON-RPC 
 [jsonrpc-spec#error_object]: http://jsonrpc.org/spec.html#error_object
 
 ```javascript
-var jayson = require('jayson');
+const jayson = require('jayson');
 
-var server = jayson.server({
+const server = jayson.server({
   invalid_params: function(args, callback) {
-    var error = this.error(-32602); // returns an error with the default properties set
+    const error = this.error(-32602); // returns an error with the default properties set
     callback(error);
   }
 });
@@ -807,9 +807,9 @@ var server = jayson.server({
 You can even override the default messages:
 
 ```javascript
-var jayson = require('jayson');
+const jayson = require('jayson');
 
-var server = jayson.server({
+const server = jayson.server({
   error_giver_of_doom: function(callback) {
     callback(true) // invalid error format, which causes an Internal Error to be returned instead
   }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -236,7 +236,7 @@ Server.prototype.call = function(request, context, originalCallback) {
 
   // compose the callback so that we may emit an event on every response
   const callback = function(error, response) {
-    self.emit('response', request, response || error);
+    self.emit('response', request, response || error, context);
     originalCallback.apply(null, arguments);
   };
 
@@ -269,7 +269,7 @@ Server.prototype.call = function(request, context, originalCallback) {
       return;
     }
 
-    self.emit('request', request);
+    self.emit('request', request, context);
 
     // is the request valid?
     if(!utils.Request.isValidRequest(request, self.options.version)) {
@@ -371,7 +371,7 @@ Server.prototype._batch = function(requests, context, callback) {
   
   const responses = [];
 
-  this.emit('batch', requests);
+  this.emit('batch', requests, context);
 
   /**
    * @ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jayson",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1066,6 +1066,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
       "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -1076,7 +1077,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -1702,7 +1704,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1873,7 +1876,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nested-error-stacks": {
       "version": "2.1.0",
@@ -1983,6 +1987,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -2797,6 +2802,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.0",
@@ -2807,12 +2813,14 @@
           "version": "2.20.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
           "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
           "optional": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }
@@ -2880,7 +2888,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",


### PR DESCRIPTION
This is helpful during logging and debugging since the emit occurs prior to method call and is especially useful for setups that change the context object from call-to-call (ex: user information in express apps).

I've also updated the documentation to reflect these changes and cleaned up some usages of "var".

Thanks for a great library!