### PR TITLE
changed RequestParamsLike to include undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ type UtilsResponse = {
   isValidResponse(response:any, version?:number): boolean;
 }
 
-export type RequestParamsLike = Array<any> | object;
+export type RequestParamsLike = Array<any> | object | undefined;
 
 export interface JSONRPCError {
   code: number;


### PR DESCRIPTION
I was having issues when requesting a method without params [] and {} resulted in bad parameter response. and typescript didn't let me insert undefined.

also the Utils.Request.isValidVersionTwoRequest allows params to be undefined