### PR TITLE
Default User-Agent header

### DIFF
--- a/lib/client/http.js
+++ b/lib/client/http.js
@@ -50,7 +50,8 @@ ClientHttp.prototype._request = function(request, callback) {
     const headers = {
       'Content-Length': Buffer.byteLength(body, options.encoding),
       'Content-Type': 'application/json; charset=utf-8',
-      'Accept': 'application/json'
+      Accept: 'application/json',
+      'User-Agent': 'jayson',
     };
 
     // let user override the headers

--- a/lib/client/http.js
+++ b/lib/client/http.js
@@ -4,6 +4,7 @@ const http = require('http');
 const url = require('url');
 const utils = require('../utils');
 const Client = require('../client');
+const { version } = require('../../package.json');
 
 /**
  *  Constructor for a Jayson HTTP Client
@@ -51,7 +52,7 @@ ClientHttp.prototype._request = function(request, callback) {
       'Content-Length': Buffer.byteLength(body, options.encoding),
       'Content-Type': 'application/json; charset=utf-8',
       Accept: 'application/json',
-      'User-Agent': 'jayson',
+      'User-Agent': `jayson-${version}`,
     };
 
     // let user override the headers


### PR DESCRIPTION
### Default `User-Agent` `Header`

AWS blocks requests made by `jayson` to its infrastructure if a WAF is enabled with the default [Common Rule Set](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html).  The current default behaviour causes this issue since no default `User-Agent` is specified

Whilst it is possible to [pass in client-specific headers via `Client.http`](https://github.com/tedeh/jayson/blob/ce06e5ff6d595cd19c6dc9cb72cd836ffdf09ff3/README.md#clienthttp), other libraries, such as `node-fetch` default the [`User-Agent` header](https://github.com/node-fetch/node-fetch/blob/1780f5ae89107ded4f232f43219ab0e548b0647c/src/request.js#L184-L186)

### Rationale
Whilst not all users of this library will be using AWS, a large majority would be.  AWS and API Gateway return particularly vague errors if this header is not included, such as [`Forbidden` or `Missing Authentication Token`](https://aws.amazon.com/premiumsupport/knowledge-center/api-gateway-troubleshoot-403-forbidden/) which would be time consuming for a developer to debug that it is caused by this missing header

Other libraries have defaulted this value and I believe that similarly, this package should be defaulting this value to `jayson` to avoid running into similar issue, especially since including this would be a small effort with a big impact on developer experience