### PR TITLE
ci: use legacy openssl flag for node 17 build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,15 @@ node_js:
   - "10"
   - "12"
 
+# Temporary workaround for Node 17
+# See: https://nodejs.org/en/blog/release/v17.0.0/#openssl-3-0
+env:
+  - NODE_OPTIONS=--openssl-legacy-provider
+
 # Notifications
 notifications:
- email:
-   - notify+mail@tedeh.net
+  email:
+    - notify+mail@tedeh.net
 
 after_success:
   - nyc npm test && nyc report --reporter=text-lcov | coveralls


### PR DESCRIPTION
> If you hit an ERR_OSSL_EVP_UNSUPPORTED error in your application with Node.js 17, it’s likely that your application or a module you’re using is attempting to use an algorithm or key size which is no longer allowed by default with OpenSSL 3.0. A command-line option, --openssl-legacy-provider, has been added to revert to the legacy provider as a temporary workaround for these tightened restrictions.

https://nodejs.org/en/blog/release/v17.0.0/#openssl-3-0

related: https://github.com/nodejs/undici/issues/1085
