### PR TITLE
Batch size limit

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -39,6 +39,7 @@ const Server = function(methods, options) {
     version: 2,
     useContext: false,
     methodConstructor: jayson.Method,
+    maxBatchSize : -1,
     router: function(method) {
       return this.getMethod(method);
     }
@@ -265,6 +266,14 @@ Server.prototype.call = function(request, context, originalCallback) {
         callback(utils.response(error, undefined, undefined, self.options.version));
         return;
       }
+
+      // case where batch size is greater than max
+      if(self.options.maxBatchSize != -1 && request.length > self.options.maxBatchSize){
+        error = self.error(Server.errors.INVALID_REQUEST);
+        callback(utils.response(error, undefined, undefined, self.options.version));
+        return;
+      }
+
       self._batch(request, context, callback);
       return;
     }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -516,6 +516,24 @@ describe('jayson.server', function() {
 
     });
 
+    it('should limit max batch size', function(done) {
+
+      server.options.maxBatchSize = 2;
+
+      const request = [ 
+        utils.request('add_slow', [1, 1, true]),
+        utils.request('add_slow', [1, 2, false]),
+        utils.request('add_slow', [1, 2, false])
+      ];
+
+      server.call(request, function(err, response) {
+        err.should.containDeep({error: {code: ServerErrors.INVALID_REQUEST}});
+        should.not.exist(response);
+        done();
+      });
+    
+    });
+    
     describe('call context', function() {
 
       beforeEach(function() {


### PR DESCRIPTION
Adds a limit to batch size using `maxBatchSize` in options. The default is unlimited(set with -1 max size) Requests with more batch query than the max return the  `INVALID_REQUEST` error.